### PR TITLE
Add `modifyInMap`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as removeKeysFromMap } from "./removeKeysFromMap";
+export { default as modifyInMap } from "./modifyInMap";

--- a/src/modifyInMap.spec.ts
+++ b/src/modifyInMap.spec.ts
@@ -1,0 +1,92 @@
+import { modifyInMap } from "./modifyInMap";
+
+describe("modifyInMap", () => {
+  it("accepts a single key", () => {
+    const out = modifyInMap({ a: 1, b: 2 }, "b", (n) => n + 1);
+    expect(out).toEqual({ a: 1, b: 3 });
+  });
+
+  it("accepts an array of keys", () => {
+    const out = modifyInMap({ a: 1, b: 2 }, ["b"], (n) => n + 1);
+    expect(out).toEqual({ a: 1, b: 3 });
+  });
+
+  it("creates a new map", () => {
+    const original: Record<string, string> = {};
+    const out = modifyInMap(original, [], (x) => x);
+    expect(original === out).toBe(false);
+  });
+
+  it("throws if a key does not exist in the map", () => {
+    const original: Record<string, number> = { a: 1, b: 2 };
+    expect(() => modifyInMap(original, ["c"], (n) => n + 1)).toThrow(
+      "Key 'c' does not exist in map."
+    );
+  });
+
+  it("does not modify the original map", () => {
+    const original = { a: 1, b: 2 };
+    const out = modifyInMap(original, "b", (n) => n + 1);
+
+    expect(out).toEqual({ a: 1, b: 3 });
+    expect(original).toEqual({ a: 1, b: 2 });
+  });
+
+  it("allows merging via destructuring", () => {
+    const original = {
+      alex: {
+        person: { name: "Alex", age: 24 },
+        job: { title: "Software Engineer" },
+      },
+      john: {
+        person: { name: "John doe", age: 27 },
+        job: { title: "UI Designer" },
+      },
+    };
+
+    const out = modifyInMap(original, "alex", (item) => ({
+      ...item,
+      person: {
+        ...item.person,
+        age: item.person.age + 1,
+      },
+    }));
+
+    expect(out).toEqual({
+      alex: {
+        person: { name: "Alex", age: 25 },
+        job: { title: "Software Engineer" },
+      },
+      john: {
+        person: { name: "John doe", age: 27 },
+        job: { title: "UI Designer" },
+      },
+    });
+    expect(out.alex === original.alex).toBe(false);
+    expect(out.alex.job === original.alex.job).toBe(true);
+    expect(out.john === original.john).toBe(true);
+  });
+
+  it("does not modify object references in the original map", () => {
+    const original = { a: { value: 1 }, b: { value: 2 } };
+    const out = modifyInMap(original, "b", (obj) => ({ value: obj.value + 1 }));
+
+    expect(out.a === original.a).toBe(true);
+    expect(out.b === original.b).toBe(false);
+
+    expect(out).toEqual({ a: { value: 1 }, b: { value: 3 } });
+    expect(original).toEqual({ a: { value: 1 }, b: { value: 2 } });
+  });
+
+  it("modifies a maps' string keys when number keys are provided", () => {
+    const original: Record<number, string> = { "1": "foo", "2": "bar" };
+    const out = modifyInMap(original, 2, (str) => str + "baz");
+    expect(out).toEqual({ "1": "foo", "2": "barbaz" });
+  });
+
+  it("modifies a maps' number keys when string keys are provided", () => {
+    const original: Record<string, string> = { [1]: "foo", [2]: "bar" };
+    const out = modifyInMap(original, "2", (str) => str + "baz");
+    expect(out).toEqual({ "1": "foo", "2": "barbaz" });
+  });
+});

--- a/src/modifyInMap.spec.ts
+++ b/src/modifyInMap.spec.ts
@@ -1,4 +1,4 @@
-import { modifyInMap } from "./modifyInMap";
+import modifyInMap from "./modifyInMap";
 
 describe("modifyInMap", () => {
   it("accepts a single key", () => {

--- a/src/modifyInMap.ts
+++ b/src/modifyInMap.ts
@@ -17,7 +17,7 @@ import { AnyMap } from "./types";
  * @param keys - The keys to modify within the map.
  * @returns A new map with modified values.
  */
-export function modifyInMap<
+export default function modifyInMap<
   M extends AnyMap,
   K extends keyof M = keyof M,
   T extends M[K] = M[K]

--- a/src/modifyInMap.ts
+++ b/src/modifyInMap.ts
@@ -1,0 +1,37 @@
+import { AnyMap } from "./types";
+
+/**
+ * Creates a new `map` populated with every key in the original `map` where the
+ * value behind each `k` in `keys` is the return value of `fn(map[k])`
+ *
+ * ```tsx
+ * const out = modifyInMap({ a: 1, b: 2 }, "b", n => n + 1);
+ * console.log(out); // { a: 1, b: 3 }
+ * ```
+ *
+ * The original `map` is not modified.
+ *
+ * @param map - The map to copy and modify.
+ * @param keys - The keys to modify within the map.
+ * @returns A new map with modified values.
+ */
+export const modifyInMap = <
+  M extends AnyMap,
+  T extends M[keyof M] = M[keyof M]
+>(
+  map: M,
+  keys: string | string[],
+  fn: (item: T) => T
+): M => {
+  const obj: M = { ...map };
+  const keyList = (Array.isArray(keys) ? keys : keys) as Array<keyof M>;
+
+  for (const key of keyList) {
+    if (!obj.hasOwnProperty(key)) {
+      throw new Error(`Key '${key}' does not exist in map.`);
+    }
+    obj[key] = fn(obj[key]);
+  }
+
+  return obj;
+};

--- a/src/modifyInMap.ts
+++ b/src/modifyInMap.ts
@@ -11,20 +11,19 @@ import { AnyMap } from "./types";
  *
  * The original `map` is not modified.
  *
+ * An error is thrown if any key in `keys` does not exist in the map.
+ *
  * @param map - The map to copy and modify.
  * @param keys - The keys to modify within the map.
  * @returns A new map with modified values.
  */
-export const modifyInMap = <
+export function modifyInMap<
   M extends AnyMap,
-  T extends M[keyof M] = M[keyof M]
->(
-  map: M,
-  keys: string | string[],
-  fn: (item: T) => T
-): M => {
+  K extends keyof M = keyof M,
+  T extends M[K] = M[K]
+>(map: M, keys: K | K[], fn: (item: T) => T): M {
   const obj: M = { ...map };
-  const keyList = (Array.isArray(keys) ? keys : keys) as Array<keyof M>;
+  const keyList = (Array.isArray(keys) ? keys : [keys]) as Array<keyof M>;
 
   for (const key of keyList) {
     if (!obj.hasOwnProperty(key)) {
@@ -34,4 +33,4 @@ export const modifyInMap = <
   }
 
   return obj;
-};
+}

--- a/src/modifyInMap.typecheck.ts
+++ b/src/modifyInMap.typecheck.ts
@@ -1,0 +1,43 @@
+import modifyInMap from "./modifyInMap";
+
+/** Keys should match the object type */
+
+// @ts-expect-error
+modifyInMap({ a: 1 }, 1, (x) => x);
+
+// @ts-expect-error
+modifyInMap({ 1: "a" }, "a", (x) => x);
+
+// No error
+modifyInMap({ a: 1 } as Record<string | number, number>, 1, (x) => x);
+
+/* Merging is not automatic deeper than at the top level */
+
+// @ts-expect-error
+modifyInMap({ alex: { name: "Alex", age: 24 } }, ["alex"], (person) => ({
+  age: person.age + 1,
+}));
+
+modifyInMap({ alex: { name: "Alex", age: 24 } }, ["alex"], (person) => ({
+  ...person,
+  age: person.age + 1,
+}));
+
+/** Non-map objects are not supported */
+
+// @ts-expect-error
+modifyInMap("a", ["a"], (x) => x);
+
+// @ts-expect-error
+modifyInMap(5, [1], (x) => x);
+
+/** Empty maps have no keys */
+
+// @ts-expect-error
+modifyInMap({}, ["a"]);
+
+// @ts-expect-error
+modifyInMap({}, [1]);
+
+// Unless they have a type
+modifyInMap({} as Record<number, number>, [1], (x) => x);

--- a/src/removeKeysFromMap.ts
+++ b/src/removeKeysFromMap.ts
@@ -1,14 +1,15 @@
 import { AnyMap } from "./types";
 
 /**
- * Creates a copy of `map` with certain keys removed.
+ * Creates a new `map` populated with every key in the original `map` except the
+ * keys that exist in the `keys` array.
  *
  * ```tsx
  * const out = removeKeysFromMap({ a: 1, b: 2 }, ["b"]);
  * console.log(out); // { a: 1 }
  * ```
  *
- * @param map - The map to remove keys from
+ * @param map - The map to remove keys from.
  * @param keys - The keys to remove from the map.
  * @returns A new map with the removed.
  */


### PR DESCRIPTION
# Changes

## Add `modifyInMap`.

```tsx
/**
 * Creates a new `map` populated with every key in the original `map` where the
 * value behind each `k` in `keys` is the return value of `fn(map[k])`
 *
 * ```tsx
 * const out = modifyInMap({ a: 1, b: 2 }, "b", n => n + 1);
 * console.log(out); // { a: 1, b: 3 }
 * ```
 *
 * The original `map` is not modified.
 *
 * An error is thrown if any key in `keys` does not exist in the map.
 *
 * @param map - The map to copy and modify.
 * @param keys - The keys to modify within the map.
 * @returns A new map with modified values.
 */
export default function modifyInMap<
  M extends AnyMap,
  K extends keyof M = keyof M,
  T extends M[K] = M[K]
>(map: M, keys: K | K[], fn: (item: T) => T): M {
  const obj: M = { ...map };
  const keyList = (Array.isArray(keys) ? keys : [keys]) as Array<keyof M>;

  for (const key of keyList) {
    if (!obj.hasOwnProperty(key)) {
      throw new Error(`Key '${key}' does not exist in map.`);
    }
    obj[key] = fn(obj[key]);
  }

  return obj;
}
```

## Update comment for `removeKeysFromMap`

Updated for consistency with `modifyInMap`.