### PR TITLE
Add `mergeInMap`

### DIFF
--- a/src/mergeInMap.spec.ts
+++ b/src/mergeInMap.spec.ts
@@ -1,0 +1,77 @@
+import mergeInMap from "./mergeInMap";
+
+describe("mergeInMap", () => {
+  it("accepts a single key", () => {
+    const out = mergeInMap(
+      { a: { p0: 1, p2: 1 }, b: { p0: 2, p1: 2 } },
+      "b",
+      (item) => ({ p0: item.p0 + 1 })
+    );
+    expect(out).toEqual({ a: { p0: 1, p2: 1 }, b: { p0: 3, p1: 2 } });
+  });
+
+  it("accepts an array of keys", () => {
+    const out = mergeInMap(
+      { a: { p0: 1, p2: 1 }, b: { p0: 2, p1: 2 } },
+      ["a", "b"],
+      (item) => ({ p0: item.p0 + 1 })
+    );
+    expect(out).toEqual({ a: { p0: 2, p2: 1 }, b: { p0: 3, p1: 2 } });
+  });
+
+  it("creates a new map", () => {
+    const original: Record<string, {}> = {};
+    const out = mergeInMap(original, [], (x) => x);
+    expect(original === out).toBe(false);
+  });
+
+  it("throws if a key does not exist in the map", () => {
+    const original: Record<string, {}> = { a: {}, b: {} };
+    expect(() => mergeInMap(original, ["c"], (x) => x)).toThrow(
+      "Key 'c' does not exist in map."
+    );
+  });
+
+  it("does not modify the original map", () => {
+    const original = { a: { value: 1 }, b: { value: 2 } };
+    const out = mergeInMap(original, "b", () => ({ value: 3 }));
+
+    expect(out).toEqual({ a: { value: 1 }, b: { value: 3 } });
+    expect(original).toEqual({ a: { value: 1 }, b: { value: 2 } });
+  });
+
+  it("does not modify object references in the original map that were not specified in keys", () => {
+    const original = { a: { value: 1 }, b: { value: 2 } };
+    const out = mergeInMap(original, "b", () => ({ value: 3 }));
+
+    expect(out.a === original.a).toBe(true);
+    expect(out.b === original.b).toBe(false);
+
+    expect(out).toEqual({ a: { value: 1 }, b: { value: 3 } });
+    expect(original).toEqual({ a: { value: 1 }, b: { value: 2 } });
+  });
+
+  it("modifies a maps' string keys when number keys are provided", () => {
+    const original: Record<number, { text: string }> = {
+      "1": { text: "foo" },
+      "2": { text: "bar" },
+    };
+    const out = mergeInMap(original, 2, () => ({ text: "baz" }));
+    expect(out).toEqual({
+      "1": { text: "foo" },
+      "2": { text: "baz" },
+    });
+  });
+
+  it("modifies a maps' number keys when string keys are provided", () => {
+    const original: Record<string, { text: string }> = {
+      [1]: { text: "foo" },
+      [2]: { text: "bar" },
+    };
+    const out = mergeInMap(original, "2", () => ({ text: "baz" }));
+    expect(out).toEqual({
+      [1]: { text: "foo" },
+      [2]: { text: "baz" },
+    });
+  });
+});

--- a/src/mergeInMap.ts
+++ b/src/mergeInMap.ts
@@ -2,8 +2,14 @@ import { AnyMap, MapOf } from "./types";
 
 /**
  * Creates a new `map` populated with every key in the original `map` where the
- * value behind each `k` in `keys` is the value `map[k]` merged with the return
- * value of `fn(map[k])`
+ * value behind each `k` in `keys` is the value `map[k]` shallowly merged with
+ * the return value of `fn(map[k])`
+ *
+ * ```tsx
+ *  newMap[k] = { ...map[k], ...fn(map[k]) };
+ * ```
+ *
+ * Example usage:
  *
  * ```tsx
  *  const out = modifyInMap(
@@ -20,7 +26,7 @@ import { AnyMap, MapOf } from "./types";
  * An error is thrown if any key in `keys` does not exist in the map.
  *
  * @param map - The map to copy and modify.
- * @param keys - The keys to modify within the map.
+ * @param keys - The keys to merge within the map.
  * @returns A new map with modified values.
  */
 export default function mergeInMap<

--- a/src/mergeInMap.ts
+++ b/src/mergeInMap.ts
@@ -1,0 +1,42 @@
+import { AnyMap } from "./types";
+
+/**
+ * Creates a new `map` populated with every key in the original `map` where the
+ * value behind each `k` in `keys` is the value `map[k]` merged with the return
+ * value of `fn(map[k])`
+ *
+ * ```tsx
+ *  const out = modifyInMap(
+ *    { alice: { age: 34, gender: "f" }, bob: { age: 42, gender: "m" } },
+ *    "alice",
+ *    person => ({ age: person.age + 1 }),
+ *  );
+ *  console.log(out.alice); // { age: 35, gender: "f" }
+ *  console.log(out.bob); // { age: 42, gender: "m" }
+ * ```
+ *
+ * The original `map` is not modified.
+ *
+ * An error is thrown if any key in `keys` does not exist in the map.
+ *
+ * @param map - The map to copy and modify.
+ * @param keys - The keys to modify within the map.
+ * @returns A new map with modified values.
+ */
+export default function mergeInMap<
+  M extends AnyMap,
+  K extends keyof M = keyof M,
+  T extends M[K] = M[K]
+>(map: M, keys: string | string[], fn: (item: T) => Partial<T>): M {
+  const obj: M = { ...map };
+  const keyList = (Array.isArray(keys) ? keys : [keys]) as Array<keyof M>;
+
+  for (const key of keyList) {
+    if (!obj.hasOwnProperty(key)) {
+      throw new Error(`Key '${key}' does not exist in map.`);
+    }
+    obj[key] = { ...obj[key], ...fn(obj[key]) };
+  }
+
+  return obj;
+}

--- a/src/mergeInMap.ts
+++ b/src/mergeInMap.ts
@@ -1,4 +1,4 @@
-import { AnyMap } from "./types";
+import { AnyMap, MapOf } from "./types";
 
 /**
  * Creates a new `map` populated with every key in the original `map` where the
@@ -24,10 +24,10 @@ import { AnyMap } from "./types";
  * @returns A new map with modified values.
  */
 export default function mergeInMap<
-  M extends AnyMap,
+  M extends MapOf<AnyMap>,
   K extends keyof M = keyof M,
   T extends M[K] = M[K]
->(map: M, keys: string | string[], fn: (item: T) => Partial<T>): M {
+>(map: M, keys: K | K[], fn: (item: T) => Partial<T>): M {
   const obj: M = { ...map };
   const keyList = (Array.isArray(keys) ? keys : [keys]) as Array<keyof M>;
 
@@ -35,7 +35,7 @@ export default function mergeInMap<
     if (!obj.hasOwnProperty(key)) {
       throw new Error(`Key '${key}' does not exist in map.`);
     }
-    obj[key] = { ...obj[key], ...fn(obj[key]) };
+    obj[key] = { ...obj[key], ...fn(obj[key] as T) };
   }
 
   return obj;

--- a/src/mergeInMap.typecheck.ts
+++ b/src/mergeInMap.typecheck.ts
@@ -1,0 +1,49 @@
+import mergeInMap from "./mergeInMap";
+
+/** Keys should match the object type */
+
+// @ts-expect-error
+mergeInMap({ a: {} }, 1, (x) => x);
+
+// @ts-expect-error
+mergeInMap({ 1: {} }, "1", (x) => x);
+
+// No error
+mergeInMap({ a: {} } as Record<string | number, {}>, 1, (x) => x);
+
+/* Expect a return value */
+
+// @ts-expect-error
+mergeInMap({ alex: { name: "Alex", age: 24 } }, ["alex"], () => {});
+
+/* Allow an empty object */
+
+mergeInMap({ alex: { name: "Alex", age: 24 } }, ["alex"], () => ({}));
+
+/* Expect properties that exist in the object */
+
+// @ts-expect-error
+mergeInMap({ alex: { name: "Alex", age: 24 } }, ["alex"], () => ({
+  jobTitle: "Software Engineer",
+}));
+
+/** Non-map objects are not supported */
+
+// @ts-expect-error
+mergeInMap("a", ["a"], (x) => x);
+
+// @ts-expect-error
+mergeInMap(5, [1], (x) => x);
+
+/** Must be MapOf<AnyMap> */
+
+// @ts-expect-error
+mergeInMap({ a: 1, b: 2 }, [1], (x) => x);
+
+/** Empty maps have no keys */
+
+// @ts-expect-error
+mergeInMap({}, ["a"], (x) => x);
+
+// Unless they have a type
+mergeInMap({} as Record<string, {}>, ["a"], (x) => x);

--- a/src/modifyInMap.ts
+++ b/src/modifyInMap.ts
@@ -23,7 +23,7 @@ export default function modifyInMap<
   T extends M[K] = M[K]
 >(map: M, keys: K | K[], fn: (item: T) => T): M {
   const obj: M = { ...map };
-  const keyList = (Array.isArray(keys) ? keys : [keys]) as Array<keyof M>;
+  const keyList = (Array.isArray(keys) ? keys : [keys]) as K[];
 
   for (const key of keyList) {
     if (!obj.hasOwnProperty(key)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,3 +5,8 @@ type Key = string | number;
 export interface AnyMap {
   [key: Key]: any;
 }
+
+/** @internal */
+export interface MapOf<T> {
+  [key: Key]: T;
+}


### PR DESCRIPTION
# Changes

## Add `mergeInMap`

```tsx
import { AnyMap } from "./types";

/**
 * Creates a new `map` populated with every key in the original `map` where the
 * value behind each `k` in `keys` is the return value of `fn(map[k])`
 *
 * ```tsx
 * const out = modifyInMap({ a: 1, b: 2 }, "b", n => n + 1);
 * console.log(out); // { a: 1, b: 3 }
 * ```
 *
 * The original `map` is not modified.
 *
 * An error is thrown if any key in `keys` does not exist in the map.
 *
 * @param map - The map to copy and modify.
 * @param keys - The keys to modify within the map.
 * @returns A new map with modified values.
 */
export default function modifyInMap<
  M extends AnyMap,
  K extends keyof M = keyof M,
  T extends M[K] = M[K]
>(map: M, keys: K | K[], fn: (item: T) => T): M {
  const obj: M = { ...map };
  const keyList = (Array.isArray(keys) ? keys : [keys]) as K[];

  for (const key of keyList) {
    if (!obj.hasOwnProperty(key)) {
      throw new Error(`Key '${key}' does not exist in map.`);
    }
    obj[key] = fn(obj[key]);
  }

  return obj;
}
```


## Minor refactor in `modifyInMap`

Use `K[]` instead of `Array<keyof M>`.