### PR TITLE
Add `addListToMap`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,13 @@
 import typescript from "@rollup/plugin-typescript";
 
 const items = [];
-const modules = ["index", "removeKeysFromMap"];
+const modules = [
+  "index",
+  "removeKeysFromMap",
+  "mergeInMap",
+  "modifyInMap",
+  "addListToMap",
+];
 
 for (const module of modules) {
   items.push({

--- a/src/addListToMap.spec.ts
+++ b/src/addListToMap.spec.ts
@@ -1,0 +1,21 @@
+import addListToMap from "./addListToMap";
+
+describe("addListToMap", () => {
+  it("adds keys as expected", () => {
+    const map: Record<string, { id: string }> = { a: { id: "a" } };
+    const out = addListToMap(map, [{ id: "b" }], "id");
+    expect(out).toEqual({ a: { id: "a" }, b: { id: "b" } });
+  });
+
+  it("overrides existing keys", () => {
+    const map: Record<string, { id: string; value: number }> = {
+      a: { id: "a", value: 1 },
+      b: { id: "b", value: 2 },
+    };
+    const out = addListToMap(map, [{ id: "b", value: 3 }], "id");
+    expect(out).toEqual({
+      a: { id: "a", value: 1 },
+      b: { id: "b", value: 3 },
+    });
+  });
+});

--- a/src/addListToMap.ts
+++ b/src/addListToMap.ts
@@ -1,0 +1,36 @@
+import { AnyMap, ItemInMap, KeysOfFilteredType } from "./types";
+
+/**
+ * Creates a new `map` populated with every item in the original `map` with every item in
+ * `items` added to the map. The key that items behind are determined by the `keyProperty`.
+ *
+ * ```tsx
+ * const map: Record<string, { id: string, value: number } }> = {
+ * 	a: { id: "a", value: 1 },
+ * };
+ *
+ * const result = addListToMap(map, [{ id: "b", value: 2 }], "id");
+ *
+ * console.log(result); // { a: { id: "a", value: 1 }, b: { id: "b", value: 2 } };
+ * ```
+ *
+ * The original `map` is not modified.
+ *
+ * @param map - The map to copy and modify.
+ * @param items - The items to add to the map
+ * @param keyProperty - The property of the items that contains the map key to use (e.g. `id`).
+ * @returns A new map with the items added to it.
+ */
+export default function addListToMap<M extends AnyMap, T extends ItemInMap<M>>(
+  map: M,
+  items: T[],
+  keyProperty: KeysOfFilteredType<T, string | number>
+): M {
+  const obj: M = { ...map };
+
+  for (const item of items) {
+    obj[item[keyProperty]] = item;
+  }
+
+  return obj;
+}

--- a/src/addListToMap.ts
+++ b/src/addListToMap.ts
@@ -21,10 +21,10 @@ import { AnyMap, ItemInMap, KeysOfFilteredType } from "./types";
  * @param keyProperty - The property of the items that contains the map key to use (e.g. `id`).
  * @returns A new map with the items added to it.
  */
-export default function addListToMap<M extends AnyMap, T extends ItemInMap<M>>(
+export default function addListToMap<M extends AnyMap>(
   map: M,
-  items: T[],
-  keyProperty: KeysOfFilteredType<T, string | number>
+  items: ItemInMap<M>[],
+  keyProperty: KeysOfFilteredType<ItemInMap<M>, keyof M>
 ): M {
   const obj: M = { ...map };
 

--- a/src/addListToMap.typecheck.ts
+++ b/src/addListToMap.typecheck.ts
@@ -1,0 +1,47 @@
+import addListToMap from "./addListToMap";
+
+/** The `keyProperty` must be a string or number */
+
+addListToMap(
+  { a: { id: "a", value: 1 } } as Record<
+    string | number,
+    { id: string; value: number }
+  >,
+  [],
+  "id"
+);
+
+addListToMap(
+  { a: { id: "a", value: 1 } } as Record<
+    string | number,
+    { id: string; value: number }
+  >,
+  [],
+  "value"
+);
+
+addListToMap(
+  { a: { id: "a", value: [1, 2, 3] } } as Record<
+    string,
+    { id: string; value: number[] }
+  >,
+  [],
+  // @ts-expect-error
+  "value"
+);
+
+/** The `keyProperty` must resolve to the same key type as the map */
+
+addListToMap(
+  { a: { id: "a", value: 1 } } as Record<string, { id: string; value: number }>,
+  [],
+  // @ts-expect-error
+  "value"
+);
+
+addListToMap(
+  { a: { id: "a", value: 1 } } as Record<number, { id: string; value: number }>,
+  [],
+  // @ts-expect-error
+  "id"
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export { default as removeKeysFromMap } from "./removeKeysFromMap";
 export { default as modifyInMap } from "./modifyInMap";
+export { default as mergeInMap } from "./mergeInMap";
+export { default as addListToMap } from "./addListToMap";

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,14 @@ export interface AnyMap {
 export interface MapOf<T> {
   [key: Key]: T;
 }
+
+/** @internal */
+export type ItemInMap<M extends AnyMap> = M[keyof M];
+
+/** @internal */
+export type FilterType<T, U, K extends keyof T = keyof T> = {
+  [_K in K as T[_K] extends U ? _K : never]: T[_K];
+};
+
+/** @internal */
+export type KeysOfFilteredType<T, U> = keyof FilterType<T, U> & string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface MapOf<T> {
 }
 
 /** @internal */
-export type ItemInMap<M extends AnyMap> = M[keyof M];
+export type ItemInMap<M extends AnyMap, T extends M[keyof M] = M[keyof M]> = T;
 
 /** @internal */
 export type FilterType<T, U, K extends keyof T = keyof T> = {
@@ -20,4 +20,5 @@ export type FilterType<T, U, K extends keyof T = keyof T> = {
 };
 
 /** @internal */
-export type KeysOfFilteredType<T, U> = keyof FilterType<T, U> & string;
+export type KeysOfFilteredType<T, U> = keyof FilterType<T, U> &
+  (string | number);


### PR DESCRIPTION
# Changes

## Add `addListToMap`

It can be used to add a list of items to an existing map:

```tsx
const map: Record<string, { id: string; value: number }> = {
  a: { id: "a", value: 1 },
};
const out = addListToMap(map, [{ id: "b", value: 2 }], "id");
console.log(out);
// out: {
//   a: { id: "a", value: 1 },
//   b: { id: "b", value: 2 },
// }
```

The function looks like so:

```tsx
/**
 * Creates a new `map` populated with every item in the original `map` with every item in
 * `items` added to the map. The key that items behind are determined by the `keyProperty`.
 *
 * ```tsx
 * const map: Record<string, { id: string, value: number } }> = {
 * 	a: { id: "a", value: 1 },
 * };
 *
 * const result = addListToMap(map, [{ id: "b", value: 2 }], "id");
 *
 * console.log(result); // { a: { id: "a", value: 1 }, b: { id: "b", value: 2 } };
 * ```
 *
 * The original `map` is not modified.
 *
 * @param map - The map to copy and modify.
 * @param items - The items to add to the map
 * @param keyProperty - The property of the items that contains the map key to use (e.g. `id`).
 * @returns A new map with the items added to it.
 */
export default function addListToMap<M extends AnyMap>(
  map: M,
  items: ItemInMap<M>[],
  keyProperty: KeysOfFilteredType<ItemInMap<M>, string | number>
): M {
  const obj: M = { ...map };

  for (const item of items) {
    obj[item[keyProperty]] = item;
  }

  return obj;
}
```

## Add `mergeInMap` to list of exports in `index`

It was forgotten in #6.


## Add individual file exports for `mergeInMap`, `modifyInMap`

They were forgotten in previous merge requests.