### PR TITLE
Always allow `string | number` for key type in `addListToMap`

### DIFF
--- a/src/addListToMap.ts
+++ b/src/addListToMap.ts
@@ -24,7 +24,7 @@ import { AnyMap, ItemInMap, KeysOfFilteredType } from "./types";
 export default function addListToMap<M extends AnyMap>(
   map: M,
   items: ItemInMap<M>[],
-  keyProperty: KeysOfFilteredType<ItemInMap<M>, keyof M>
+  keyProperty: KeysOfFilteredType<ItemInMap<M>, string | number>
 ): M {
   const obj: M = { ...map };
 

--- a/src/addListToMap.typecheck.ts
+++ b/src/addListToMap.typecheck.ts
@@ -2,46 +2,34 @@ import addListToMap from "./addListToMap";
 
 /** The `keyProperty` must be a string or number */
 
-addListToMap(
-  { a: { id: "a", value: 1 } } as Record<
-    string | number,
-    { id: string; value: number }
-  >,
-  [],
-  "id"
-);
+addListToMap({ a: { id: "a", value: 1 } }, [], "id");
+
+addListToMap({ a: { id: "a", value: 1 } }, [], "value");
 
 addListToMap(
-  { a: { id: "a", value: 1 } } as Record<
-    string | number,
-    { id: string; value: number }
-  >,
-  [],
-  "value"
-);
-
-addListToMap(
-  { a: { id: "a", value: [1, 2, 3] } } as Record<
-    string,
-    { id: string; value: number[] }
-  >,
+  { a: { id: "a", value: [1, 2, 3] } },
   [],
   // @ts-expect-error
   "value"
 );
 
-/** The `keyProperty` must resolve to the same key type as the map */
+addListToMap(
+  { a: { id: "a", value: 1 } },
+  [],
+  // @ts-expect-error
+  "doesnotexist"
+);
+
+/** Allow `keyProperty` to be a string or a number, even if the key type does not match */
 
 addListToMap(
   { a: { id: "a", value: 1 } } as Record<string, { id: string; value: number }>,
   [],
-  // @ts-expect-error
   "value"
 );
 
 addListToMap(
   { a: { id: "a", value: 1 } } as Record<number, { id: string; value: number }>,
   [],
-  // @ts-expect-error
   "id"
 );


### PR DESCRIPTION
It feels silly that this is a type error:

![image](https://user-images.githubusercontent.com/20321920/147161141-f5e6fcea-2e8f-492a-a13d-be99a5503766.png)

It can be fixed via explicit typing:

```tsx
const map: Record<string, { id: string }> = { a: { id: "a" }, b: { id: "b" } };

addListToMap(map, [{ id: "c" }], "id");
```

`keyProperty` in the first example is `never` because it resolves to:

```tsx
keyProperty: KeysOfFilteredType<ItemInMap<M>, "a" | "b">
```

This merge request changes this to:

```tsx
keyProperty: KeysOfFilteredType<ItemInMap<M>, string | number>
```

It could be considered technically incorrect, but all keys are converted to string anyway:

![image](https://user-images.githubusercontent.com/20321920/147161487-5d74d72d-d932-4aa3-aeae-ec15c1c0be1d.png)

so it doesn't really matter.