### PR TITLE
Add script to validate the build output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Build
+        run: npm run build:validate-output
+
       - name: Release
         run: npm run release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Build
+      - name: Validate build
         run: npm run build:validate-output
 
       - name: Release

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Test
         run: npm run test:ci
 
-      - name: Build # Ensure that the build is successful when it reaches master
+      - name: Build
         run: npm run build
+
+      - name: Validate build
+        run: npm run build:validate-output

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,6 +1193,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1771,6 +1786,30 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.17",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.17.tgz",
@@ -2058,6 +2097,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2596,6 +2641,12 @@
         "yaml": "^1.10.0"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2786,6 +2837,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -4517,6 +4574,12 @@
       "requires": {
         "semver": "^6.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -8160,6 +8223,34 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
+    "ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -8469,6 +8560,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:prepare": "npm run build:remove-old-build",
     "build:copy-files": "cp README.md package.json dist/",
     "build:remove-old-build": "rm -rf dist/ && rm -rf out/",
+    "build:validate-output": "ts-node -T -O '{\"module\":\"commonjs\",\"esModuleInterop\":true}' scripts/validate-build-output",
     "release": "cd dist && semantic-release"
   },
   "devDependencies": {
@@ -25,6 +26,7 @@
     "jest": "^27.4.4",
     "rollup": "^2.61.1",
     "semantic-release": "^18.0.1",
+    "ts-node": "^10.4.0",
     "tslib": "^2.3.1",
     "typescript": "^4.5.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import typescript from "@rollup/plugin-typescript";
 const items = [];
 const modules = [
   "index",
-  // "removeKeysFromMap",
+  "removeKeysFromMap",
   "mergeInMap",
   "modifyInMap",
   "addListToMap",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import typescript from "@rollup/plugin-typescript";
 const items = [];
 const modules = [
   "index",
-  "removeKeysFromMap",
+  // "removeKeysFromMap",
   "mergeInMap",
   "modifyInMap",
   "addListToMap",

--- a/scripts/validate-build-output.ts
+++ b/scripts/validate-build-output.ts
@@ -1,0 +1,101 @@
+import fs from "fs";
+import path from "path";
+
+const fnsDir = path.resolve(__dirname, "../src");
+const distDir = path.resolve(__dirname, "../dist");
+
+const allFileNames = fs.readdirSync(fnsDir);
+
+const allFileNamesSet = new Set(allFileNames);
+
+const fnFileNames = allFileNames.filter((fileName) => {
+  if (fileName.endsWith(".spec.ts") || fileName.endsWith(".typecheck.ts")) {
+    return false;
+  }
+
+  if (!fileName.endsWith(".ts")) {
+    return false;
+  }
+
+  const withoutDotTs = fileName.split(".ts")[0];
+
+  const hasSpecTs = allFileNamesSet.has(`${withoutDotTs}.spec.ts`);
+  const hasTypecheckTs = allFileNamesSet.has(`${withoutDotTs}.typecheck.ts`);
+
+  if (!hasSpecTs || !hasTypecheckTs) {
+    return false;
+  }
+
+  return true;
+});
+
+console.log("Found source .ts files for the following functions:\n");
+console.log(
+  fnFileNames.map((fileName) => `\t${fileName.split(".ts")[0]}`).join("\n")
+);
+console.log(
+  "\nChecking that .js and .d.ts files were emitted to ~/dist for each function (and index).\n"
+);
+
+const fileNamesToCheck = ["index.ts", ...fnFileNames];
+
+for (const fileName of fileNamesToCheck) {
+  const withoutDotTs = fileName.split(".ts")[0];
+
+  for (const ext of [".js", ".d.ts"]) {
+    const filePath = path.resolve(distDir, `./${withoutDotTs}${ext}`);
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Expected '${ext}' file for function '${withoutDotTs}'.`);
+    }
+  }
+
+  console.log(`\t✔ ${withoutDotTs}`);
+}
+
+console.log("\nEnsuring that the index.js file exports every function.\n");
+
+const indexJsFilePath = path.resolve(distDir, "./index.js");
+const indexDtsFilePath = path.resolve(distDir, "./index.d.ts");
+
+const indexJsContent = fs.readFileSync(indexJsFilePath, "utf8");
+const indexJsExportStatementSet = new Set(
+  indexJsContent.split("\n").filter((line) => line.startsWith("exports."))
+);
+
+for (const fileName of fnFileNames) {
+  const withoutDotTs = fileName.split(".ts")[0];
+  if (
+    !indexJsExportStatementSet.has(`exports.${withoutDotTs} = ${withoutDotTs};`)
+  ) {
+    throw new Error(
+      `Did not find export statement in index.js bundle for '${withoutDotTs}'.`
+    );
+  }
+
+  console.log(`\t✔ ${withoutDotTs}`);
+}
+
+console.log("\nEnsuring that the index.d.ts file exports every function.\n");
+
+const indexDtsContent = fs.readFileSync(indexDtsFilePath, "utf8");
+const indexDtsExportStatementSet = new Set(
+  indexDtsContent
+    .split("\n")
+    .filter((line) => line.startsWith("export { default as "))
+);
+
+for (const fileName of fnFileNames) {
+  const withoutDotTs = fileName.split(".ts")[0];
+  if (
+    !indexDtsExportStatementSet.has(
+      `export { default as ${withoutDotTs} } from "./${withoutDotTs}";`
+    )
+  ) {
+    throw new Error(
+      `Did not find export statement in index.d.ts bundle for '${withoutDotTs}'.`
+    );
+  }
+
+  console.log(`\t✔ ${withoutDotTs}`);
+}

--- a/scripts/validate-build-output.ts
+++ b/scripts/validate-build-output.ts
@@ -1,11 +1,10 @@
 import fs from "fs";
 import path from "path";
 
-const fnsDir = path.resolve(__dirname, "../src");
+const srcDir = path.resolve(__dirname, "../src");
 const distDir = path.resolve(__dirname, "../dist");
 
-const allFileNames = fs.readdirSync(fnsDir);
-
+const allFileNames = fs.readdirSync(srcDir);
 const allFileNamesSet = new Set(allFileNames);
 
 const fnFileNames = allFileNames.filter((fileName) => {


### PR DESCRIPTION
# Problem

When adding functions in previous merge requests, I've forgotten to include them in the build output.

The PR to add the `mergeInMap` function (#6) did not export the function from `index.js` or emit `.js` and `.d.ts` files to `~/dist` on `npm run build` since I forgot to add it to `modules` in `rollup.config.js`.


# Changes

## Add `validate-build-output` script

It can be run via `npm run build:validate-output`.

It checks that:

 * Every function file in `~/src` results in a `.js` and `.d.ts` file in `~/dist` after running `npm run build`
 * `index.js` and `index.d.ts` files are emitted in `~/dist` after running `npm run build`
 * The emitted `index.js` and `index.d.ts` files export every function.

A file in `~/src` is considered to be a function file if `~/src` contains corresponding `.spec.ts` and `.typecheck.ts` files.


## Run build validation in workflows

It is run in the `publish` and `pull_request` workflows.