### PR TITLE
Add `mapMap` function

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ const modules = [
   "mergeInMap",
   "modifyInMap",
   "addListToMap",
+  "mapMap",
 ];
 
 for (const module of modules) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as removeKeysFromMap } from "./removeKeysFromMap";
 export { default as modifyInMap } from "./modifyInMap";
 export { default as mergeInMap } from "./mergeInMap";
 export { default as addListToMap } from "./addListToMap";
+export { default as mapMap } from "./mapMap";

--- a/src/mapMap.spec.ts
+++ b/src/mapMap.spec.ts
@@ -1,0 +1,32 @@
+import mapMap from "./mapMap";
+
+describe("mapMap", () => {
+  it("transforms a map as expected", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    const out = mapMap(map, (n) => n * 2);
+    expect(out).toEqual({ a: 2, b: 4, c: 6 });
+  });
+
+  it("does not modify the original map", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    const out = mapMap(map, (n) => n * 2);
+    expect(map).toEqual({ a: 1, b: 2, c: 3 });
+    expect(out).toEqual({ a: 2, b: 4, c: 6 });
+  });
+
+  it("does not modify object references in the original map", () => {
+    const a = { value: 1 };
+    const b = { value: 2 };
+    const c = { value: 3 };
+    const map = { a, b, c };
+    const out = mapMap(map, (item) => ({ value: item.value * 2 }));
+    expect(map).toEqual({ a: { value: 1 }, b: { value: 2 }, c: { value: 3 } });
+    expect(out).toEqual({ a: { value: 2 }, b: { value: 4 }, c: { value: 6 } });
+    expect(map.a === a).toBe(true);
+    expect(map.b === b).toBe(true);
+    expect(map.c === c).toBe(true);
+    expect(out.a === a).toBe(false);
+    expect(out.b === b).toBe(false);
+    expect(out.c === c).toBe(false);
+  });
+});

--- a/src/mapMap.ts
+++ b/src/mapMap.ts
@@ -15,7 +15,7 @@ export default function mapMap<M extends AnyMap, T>(
   const obj = {} as Record<keyof M, T>;
   const keys = Object.keys(map) as Array<keyof M>;
 
-  for (const key in keys) {
+  for (const key of keys) {
     obj[key] = fn(map[key]);
   }
 

--- a/src/mapMap.ts
+++ b/src/mapMap.ts
@@ -2,7 +2,7 @@ import { AnyMap, ItemInMap } from "./types";
 
 /**
  * Creates a new `map` populated with every key in the original `map` where the
- * value behind each `k` in `keys` is the return value of `fn(map[k])`.
+ * value of each key `k` in the new map is the return value of `fn(map[k])`.
  *
  * @param map The original map.
  * @param fn A function that takes a single argument `map[k]` and returns the value of `newMap[k]`.

--- a/src/mapMap.ts
+++ b/src/mapMap.ts
@@ -1,0 +1,23 @@
+import { AnyMap, ItemInMap } from "./types";
+
+/**
+ * Creates a new `map` populated with every key in the original `map` where the
+ * value behind each `k` in `keys` is the return value of `fn(map[k])`.
+ *
+ * @param map The original map.
+ * @param fn A function that takes a single argument `map[k]` and returns the value of `newMap[k]`.
+ * @returns A new `map` where `map[k]` is the result of `fn(map[k])`.
+ */
+export default function mapMap<M extends AnyMap, T>(
+  map: M,
+  fn: (item: ItemInMap<M>) => T
+) {
+  const obj = {} as Record<keyof M, T>;
+  const keys = Object.keys(map) as Array<keyof M>;
+
+  for (const key in keys) {
+    obj[key] = fn(map[key]);
+  }
+
+  return obj;
+}

--- a/src/mapMap.typecheck.ts
+++ b/src/mapMap.typecheck.ts
@@ -1,0 +1,8 @@
+import mapMap from "./mapMap";
+
+/** Types are correctly inferred */
+
+mapMap({ a: 1 }, (n) => n * 2);
+
+// @ts-expect-error
+mapMap({ a: "1" }, (n) => n * 2);


### PR DESCRIPTION
# Changes

## Add `mapMap` function

It is the map equivalent of `array.map`. It is useful when transforming the map to a new map which contains every key in the original map and the values are derived from the original map:

```tsx
// Get a specific property in a map
const idToValue = mapMap(itemMap, (item) => item.value);

// Get a few properties in a map
const subsetOfItemMap = mapMap(itemMap, ({ a, b }) => ({ a, b }));

// Compute something based on the items in a map
const idToComputedValue = mapMap(itemMap, (item) => computeValue(item.id));
```

The implementation is quite simple:

```tsx
/**
 * Creates a new `map` populated with every key in the original `map` where the
 * value of each key `k` in the new map is the return value of `fn(map[k])`.
 *
 * @param map The original map.
 * @param fn A function that takes a single argument `map[k]` and returns the value of `newMap[k]`.
 * @returns A new `map` where `map[k]` is the result of `fn(map[k])`.
 */
export default function mapMap<M extends AnyMap, T>(
  map: M,
  fn: (item: ItemInMap<M>) => T
) {
  const obj = {} as Record<keyof M, T>;
  const keys = Object.keys(map) as Array<keyof M>;

  for (const key of keys) {
    obj[key] = fn(map[key]);
  }

  return obj;
}
```
