### PR TITLE
Add `mapEntries` function

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ const modules = [
   "modifyInMap",
   "addListToMap",
   "mapMap",
+  "mapEntries",
 ];
 
 for (const module of modules) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { default as modifyInMap } from "./modifyInMap";
 export { default as mergeInMap } from "./mergeInMap";
 export { default as addListToMap } from "./addListToMap";
 export { default as mapMap } from "./mapMap";
+export { default as mapEntries } from "./mapEntries";

--- a/src/mapEntries.spec.ts
+++ b/src/mapEntries.spec.ts
@@ -1,5 +1,4 @@
 import mapEntries from "./mapEntries";
-import { AnyMap } from "./types";
 
 describe("mapEntries", () => {
   it("returns the entries of a map", () => {

--- a/src/mapEntries.spec.ts
+++ b/src/mapEntries.spec.ts
@@ -1,0 +1,65 @@
+import mapEntries from "./mapEntries";
+import { AnyMap } from "./types";
+
+describe("mapEntries", () => {
+  it("returns the entries of a map", () => {
+    const entries = mapEntries({ x: 1, y: 2 });
+    expect(entries).toEqual([
+      ["x", 1],
+      ["y", 2],
+    ]);
+  });
+
+  it("filters the entries if the second keys argument is provided", () => {
+    const entries = mapEntries({ x: 1, y: 2, z: 3 }, ["y", "z"]);
+    expect(entries).toEqual([
+      ["y", 2],
+      ["z", 3],
+    ]);
+  });
+
+  it("returns the entries in the order of the provided keys", () => {
+    const map = { x: 1, y: 2, z: 3 };
+
+    expect(mapEntries(map, ["y", "z", "x"])).toEqual([
+      ["y", 2],
+      ["z", 3],
+      ["x", 1],
+    ]);
+    expect(mapEntries(map, ["z", "y", "x"])).toEqual([
+      ["z", 3],
+      ["y", 2],
+      ["x", 1],
+    ]);
+  });
+
+  it("returns an empty array if an empty array of keys is provided", () => {
+    expect(mapEntries({ x: 1, y: 2, z: 3 }, [])).toEqual([]);
+  });
+
+  it("returns an empty array if the map contains no entries", () => {
+    expect(mapEntries({})).toEqual([]);
+  });
+
+  it("throws an error if a keys contains a key not present in the map", () => {
+    const map: Record<string, number> = { x: 1, y: 2 };
+    expect(() => mapEntries(map, ["z"])).toThrow(
+      "Key 'z' does not exist in map."
+    );
+  });
+
+  it("retains object references correctly", () => {
+    const x = { value: 1 };
+    const y = { value: 2 };
+    const map = { x, y };
+    const out = mapEntries(map);
+    expect(out[0][0]).toEqual("x");
+    expect(out[0][1] === x).toBe(true);
+    expect(out[1][0]).toEqual("y");
+    expect(out[1][1] === y).toBe(true);
+
+    // Sanity checks
+    expect(out[0][1] === { ...x }).toBe(false);
+    expect(out[1][1] === { ...y }).toBe(false);
+  });
+});

--- a/src/mapEntries.spec.ts
+++ b/src/mapEntries.spec.ts
@@ -61,4 +61,14 @@ describe("mapEntries", () => {
     expect(out[0][1] === { ...x }).toBe(false);
     expect(out[1][1] === { ...y }).toBe(false);
   });
+
+  it("can be used to populate a Map", () => {
+    const map = { x: 1, y: 2 };
+
+    const m = new Map(mapEntries(map));
+
+    expect(m.get("x")).toEqual(1);
+    expect(m.get("y")).toEqual(2);
+    expect(m.size).toEqual(2);
+  });
 });

--- a/src/mapEntries.ts
+++ b/src/mapEntries.ts
@@ -1,0 +1,35 @@
+import { AnyMap, ItemInMap } from "./types";
+
+/**
+ * Returns a new array of key, value entries from the provided map. The keys of the entries
+ * to return may be provided via the `keys` argument.
+ *
+ * ```tsx
+ * const entries = mapEntries({ a: 1, b: 2, c: 3 });
+ * // > [["a", 1], ["b", 2] ["c", 3]]
+ *
+ * const entries = mapEntries({ a: 1, b: 2, c: 3 }, ["b", "a"]);
+ * // > [["b", 2], ["a", 1]]
+ * ```
+ *
+ * @param map The map to get the entries of.
+ * @param keys The keys in the map to return as entries.
+ * @returns An array of key, value pairs for every entry in the map. If `keys` is provided, only the entries for those keys are included.
+ */
+export default function mapEntries<
+  M extends AnyMap,
+  K extends keyof M = keyof M
+>(map: M, keys?: K[]): Array<[K, ItemInMap<M>]> {
+  const keysToUse = keys || (Object.keys(map) as K[]);
+
+  const entries: Array<[K, ItemInMap<M>]> = [];
+
+  for (const key of keysToUse) {
+    if (!map.hasOwnProperty(key)) {
+      throw new Error(`Key '${key}' does not exist in map.`);
+    }
+    entries.push([key, map[key]]);
+  }
+
+  return entries;
+}

--- a/src/mapEntries.typecheck.ts
+++ b/src/mapEntries.typecheck.ts
@@ -1,0 +1,23 @@
+import mapEntries from "./mapEntries";
+
+/* The keys to return the entries for can be omitted */
+
+mapEntries({ x: 1 });
+
+/* They can also be provided */
+
+mapEntries({ x: 1 }, ["x"]);
+
+/* It returns errors if keys that don't exist in the map are provided */
+
+// @ts-expect-error
+mapEntries({ x: 1 }, ["y"]);
+
+/* But no errors if the keys exist, according to types */
+
+mapEntries({ x: 1 } as Record<string, number>, ["y"]);
+
+/* We currently only allow a list of keys, not a single key */
+
+// @ts-expect-error
+mapEntries({ x: 1 }, "x");


### PR DESCRIPTION
# Changes

## Add `mapEntries` function

This function is useful if you want to iterate over the key, value pairs in the map:

```tsx
for (const [key, value] of mapEntries(map)) {
  // ...
}
```

If you only need to iterate over a subset of the entries, the keys to iterate over can be provided as the second argument:

```tsx
for (const [key, value] of mapEntries(map, ["a", "b"])) {
  // ...
}
```

It can also be used to populate a `Map`:

```tsx
new Map(mapEntries(map));
```

### Why not use `Object.entries()`, `Object.values()` or `Object.keys()`?

All of those can be used instead (depending on the use case), but `mapEntries` provides additional value.


#### Comparison with `Object.entries()`

`mapEntries` can take a second `keys` argument to specify which keys to iterate over.

```tsx
// With Object.entries()
const keySet = new Set(["a", "b"]);
for (const [key, value] of Object.entries(map).filter((key) => keySet.has(key))) {
  // ...
}

// With mapEntries
for (const [key, value] of mapEntries(map, ["a", "b"])) {
  // ...
}
```

`Object.entries()` is also not supported on some older browsers (see https://caniuse.com/object-entries).


#### Comparison with `Object.values()`

If you only need to use the values (and do not need to filter the entries via `keys`) I would recommend using `Object.values` over `mapEntries`:

```tsx
// With Object.values()
for (const value of Object.values(map)) {
  // ...
}

// With mapEntries
for (const [, value] of mapEntries(map)) {
  // ...
}
```

If you need the values of a known set of keys, then `mapEntries` can provide value:

```tsx
for (const [, value] of mapEntries(map, ["a", "b"])) {
  // ...
}
```


#### Comparison with `Object.keys()`

If you only need to use the keys I would recommend using `Object.keys` over `mapEntries`:

```tsx
// With Object.keys()
for (const key of Object.keys(map)) {
  // ...
}

// With mapEntries
for (const [key] of mapEntries(map)) {
  // ...
}
```

If you need to iterate over a known set of keys I would recommend iterating over them directly:

```tsx
for (const key of ["a", "b"]) {
  // ...
}
```

`mapEntries` provides no value when only iterating over the keys.