### PR TITLE
Add `areMapsShallowEqual` function

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ const modules = [
   "addListToMap",
   "mapMap",
   "mapEntries",
+  "areMapsShallowEqual",
 ];
 
 for (const module of modules) {

--- a/src/areMapsShallowEqual.spec.ts
+++ b/src/areMapsShallowEqual.spec.ts
@@ -1,0 +1,49 @@
+import areMapsShallowEqual from "./areMapsShallowEqual";
+
+describe("areMapsShallowEqual", () => {
+  it("returns true for the same map", () => {
+    const map = { x: { value: 1 }, y: { value: 2 } };
+    expect(areMapsShallowEqual(map, map)).toEqual(true);
+  });
+
+  it("returns false for maps with no overlap", () => {
+    const a: Record<string, { value: number }> = { y: { value: 2 } };
+    const b: Record<string, { value: number }> = { x: { value: 1 } };
+    expect(areMapsShallowEqual(a, b)).toEqual(false);
+  });
+
+  it("returns false for maps with partial overlap", () => {
+    const a: Record<string, { value: number }> = {
+      y: { value: 2 },
+      z: { value: 3 },
+    };
+    const b: Record<string, { value: number }> = {
+      x: { value: 1 },
+      y: { value: 2 },
+    };
+    expect(areMapsShallowEqual(a, b)).toEqual(false);
+  });
+
+  it("returns true, even if the maps are different object references", () => {
+    const a = { x: { value: 1 }, y: { value: 2 } };
+    const b = { ...a };
+    expect(areMapsShallowEqual(a, b)).toEqual(true);
+  });
+
+  it("returns false when an item in the map is a different object reference", () => {
+    const a = { x: { value: 1 }, y: { value: 2 } };
+    const b = { ...a, x: { ...a.x } };
+    expect(a).toEqual(b);
+    expect(areMapsShallowEqual(a, b)).toEqual(false);
+  });
+
+  it("correctly compares primitive maps", () => {
+    const a = { x: 1, y: 2 };
+    const b = { x: 1, y: 2 };
+    const c = { y: 2 };
+    const d = { x: 1, y: 3 };
+    expect(areMapsShallowEqual(a, b)).toEqual(true);
+    expect(areMapsShallowEqual(a, c)).toEqual(false);
+    expect(areMapsShallowEqual(a, d)).toEqual(false);
+  });
+});

--- a/src/areMapsShallowEqual.ts
+++ b/src/areMapsShallowEqual.ts
@@ -1,0 +1,37 @@
+import { AnyMap } from "./types";
+
+/**
+ * Takes in two maps and returns true if they contain the same keys and the values behind
+ * their keys are shallowly equal. Returns false otherwise.
+ *
+ * This function can be useful to check if changes have occurred in any of the items in
+ * the map.
+ *
+ * The order that the maps are provided in does not matter.
+ *
+ * @param a First map to compare
+ * @param b Second map to compare
+ * @returns True if they are equal, False if they are not
+ */
+export function areMapsShallowEqual<M extends AnyMap>(a: M, b: M): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  for (let i = 0; i < aKeys.length; i += 1) {
+    const key = aKeys[i];
+
+    if (!b.hasOwnProperty(key)) {
+      return false;
+    }
+
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/areMapsShallowEqual.ts
+++ b/src/areMapsShallowEqual.ts
@@ -13,7 +13,10 @@ import { AnyMap } from "./types";
  * @param b Second map to compare
  * @returns True if they are equal, False if they are not
  */
-export function areMapsShallowEqual<M extends AnyMap>(a: M, b: M): boolean {
+export default function areMapsShallowEqual<M extends AnyMap>(
+  a: M,
+  b: M
+): boolean {
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
 

--- a/src/areMapsShallowEqual.ts
+++ b/src/areMapsShallowEqual.ts
@@ -1,11 +1,11 @@
 import { AnyMap } from "./types";
 
 /**
- * Takes in two maps and returns true if they contain the same keys and the values behind
- * their keys are shallowly equal. Returns false otherwise.
+ * Takes in two maps and returns true if they contain the same keys and the
+ * values behind their keys are shallowly equal. Returns false otherwise.
  *
- * This function can be useful to check if changes have occurred in any of the items in
- * the map.
+ * This function can be useful to check if changes have occurred in any of
+ * the items in the map.
  *
  * The order that the maps are provided in does not matter.
  *

--- a/src/areMapsShallowEqual.typecheck.ts
+++ b/src/areMapsShallowEqual.typecheck.ts
@@ -1,0 +1,25 @@
+import areMapsShallowEqual from "./areMapsShallowEqual";
+
+areMapsShallowEqual({}, {});
+
+// @ts-expect-error
+areMapsShallowEqual({});
+
+/* It returns an error if maps with different keys are compared */
+
+{
+  const a = { x: 1 };
+  const b = { y: 2 };
+
+  // @ts-expect-error
+  areMapsShallowEqual(a, b);
+}
+
+/* Unless they are properly typed */
+
+{
+  const a: Record<string, number> = { x: 1 };
+  const b: Record<string, number> = { y: 2 };
+
+  areMapsShallowEqual(a, b);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { default as mergeInMap } from "./mergeInMap";
 export { default as addListToMap } from "./addListToMap";
 export { default as mapMap } from "./mapMap";
 export { default as mapEntries } from "./mapEntries";
+export { default as areMapsShallowEqual } from "./areMapsShallowEqual";


### PR DESCRIPTION
# Changes

## Add `areMapsShallowEqual` function

`areMapsShallowEqual` can be used to check if two maps are shallowly equal.

Two maps `a` and `b` are considered shallowly equal if:

 * They contain the same number of keys and `a` contains every key in `b`
 * For every key `k` in `a`, running `a[k] === b[k]` returns `true`

Note that the comparison `a === b` does not have to return `true` for `areMapsShallowEqual` to return `true`. This function is only concerned with checking that the items in the maps are equal.

The implementation looks like so:

```tsx
/**
 * Takes in two maps and returns true if they contain the same keys and the values behind
 * their keys are shallowly equal. Returns false otherwise.
 *
 * This function can be useful to check if changes have occurred in any of the items in
 * the map.
 *
 * The order that the maps are provided in does not matter.
 *
 * @param a First map to compare
 * @param b Second map to compare
 * @returns True if they are equal, False if they are not
 */
export default function areMapsShallowEqual<M extends AnyMap>(
  a: M,
  b: M
): boolean {
  const aKeys = Object.keys(a);
  const bKeys = Object.keys(b);

  if (aKeys.length !== bKeys.length) {
    return false;
  }

  for (let i = 0; i < aKeys.length; i += 1) {
    const key = aKeys[i];

    if (!b.hasOwnProperty(key)) {
      return false;
    }

    if (a[key] !== b[key]) {
      return false;
    }
  }

  return true;
}
```