### PR TITLE
Add ESM modules to the build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "map-fns",
   "main": "index.js",
+  "module": "index.esm.js",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "map-fns",
   "main": "index.js",
   "module": "index.esm.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,10 @@ for (const module of modules) {
   items.push({
     input: `src/${module}.ts`,
     external: [],
-    output: [{ file: `dist/${module}.js`, format: "cjs" }],
+    output: [
+      { file: `dist/${module}.js`, format: "cjs", exports: "auto" },
+      { file: `dist/${module}.esm.js`, format: "es" },
+    ],
     plugins: [
       typescript({
         tsconfig: "./tsconfig.json",

--- a/scripts/validate-build-output.ts
+++ b/scripts/validate-build-output.ts
@@ -33,7 +33,7 @@ console.log(
   fnFileNames.map((fileName) => `\t${fileName.split(".ts")[0]}`).join("\n")
 );
 console.log(
-  "\nChecking that .js and .d.ts files were emitted to ~/dist for each function (and index).\n"
+  "\nChecking that .js, .esm.js and .d.ts files were emitted to ~/dist for each function (and index).\n"
 );
 
 const fileNamesToCheck = ["index.ts", ...fnFileNames];
@@ -41,7 +41,7 @@ const fileNamesToCheck = ["index.ts", ...fnFileNames];
 for (const fileName of fileNamesToCheck) {
   const withoutDotTs = fileName.split(".ts")[0];
 
-  for (const ext of [".js", ".d.ts"]) {
+  for (const ext of [".js", ".esm.js", ".d.ts"]) {
     const filePath = path.resolve(distDir, `./${withoutDotTs}${ext}`);
 
     if (!fs.existsSync(filePath)) {
@@ -54,18 +54,22 @@ for (const fileName of fileNamesToCheck) {
 
 console.log("\nEnsuring that the index.js file exports every function.\n");
 
-const indexJsFilePath = path.resolve(distDir, "./index.js");
+const indexCjsFilePath = path.resolve(distDir, "./index.js");
+const indexEsmFilePath = path.resolve(distDir, "./index.esm.js");
 const indexDtsFilePath = path.resolve(distDir, "./index.d.ts");
 
-const indexJsContent = fs.readFileSync(indexJsFilePath, "utf8");
-const indexJsExportStatementSet = new Set(
-  indexJsContent.split("\n").filter((line) => line.startsWith("exports."))
+const indexCjsContent = fs.readFileSync(indexCjsFilePath, "utf8");
+const indexCjsExportStatementSet = new Set(
+  indexCjsContent.split("\n").filter((line) => line.startsWith("exports."))
 );
+const indexEsmContent = fs.readFileSync(indexEsmFilePath, "utf8");
 
 for (const fileName of fnFileNames) {
   const withoutDotTs = fileName.split(".ts")[0];
   if (
-    !indexJsExportStatementSet.has(`exports.${withoutDotTs} = ${withoutDotTs};`)
+    !indexCjsExportStatementSet.has(
+      `exports.${withoutDotTs} = ${withoutDotTs};`
+    )
   ) {
     throw new Error(
       `Did not find export statement in index.js bundle for '${withoutDotTs}'.`
@@ -73,6 +77,34 @@ for (const fileName of fnFileNames) {
   }
 
   console.log(`\t✔ ${withoutDotTs}`);
+}
+
+console.log("\nEnsuring that the index.esm.js file exports every function.\n");
+
+{
+  // Check that index.esm.js contains every export that it should
+  const line = indexEsmContent
+    .split("\n")
+    .find((line) => line.startsWith("export {"));
+  const exports = new Set(
+    line
+      .split("export {")[1]
+      .split("}")[0]
+      .split(",")
+      .map((str) => str.trim())
+      .filter(Boolean)
+  );
+
+  for (const fileName of fnFileNames) {
+    const withoutDotTs = fileName.split(".ts")[0];
+    if (!exports.has(withoutDotTs)) {
+      throw new Error(
+        `Expected index.esm.js to export function '${withoutDotTs}'.`
+      );
+    }
+
+    console.log(`\t✔ ${withoutDotTs}`);
+  }
 }
 
 console.log("\nEnsuring that the index.d.ts file exports every function.\n");

--- a/scripts/validate-build-output.ts
+++ b/scripts/validate-build-output.ts
@@ -82,22 +82,20 @@ for (const fileName of fnFileNames) {
 console.log("\nEnsuring that the index.esm.js file exports every function.\n");
 
 {
-  // Check that index.esm.js contains every export that it should
-  const line = indexEsmContent
-    .split("\n")
-    .find((line) => line.startsWith("export {"));
-  const exports = new Set(
-    line
-      .split("export {")[1]
-      .split("}")[0]
-      .split(",")
-      .map((str) => str.trim())
-      .filter(Boolean)
-  );
+  // The end of index.esm.js should contain a line that exports every function:
+  //
+  //    export { fnA, fnB, fnC };
+  //
+  // This regex matches the function list "fnA, fnB, fnC".
+  //
+  const exportsRegex = /export { (?<exportsStr>([a-z]+(, )?)+) }/i;
+
+  const { exportsStr } = indexEsmContent.match(exportsRegex)!.groups;
+  const exportedFunctionsSet = new Set(exportsStr.split(", ").filter(Boolean));
 
   for (const fileName of fnFileNames) {
     const withoutDotTs = fileName.split(".ts")[0];
-    if (!exports.has(withoutDotTs)) {
+    if (!exportedFunctionsSet.has(withoutDotTs)) {
       throw new Error(
         `Expected index.esm.js to export function '${withoutDotTs}'.`
       );


### PR DESCRIPTION
# Changes

## Add ESM modules to the build output

The `dist` directory now looks like so after running `npm run build`:

```
package.json
README
index.js
index.esm.js
index.d.ts
mergeInMap.js
mergeInMap.esm.js
mergeInMap.d.ts
...
```

ESM modules are tree-shakable. See https://webpack.js.org/guides/tree-shaking/

> Tree shaking is a term commonly used in the JavaScript context for dead-code elimination. It relies on the static structure of ES2015 module syntax, i.e. import and export.

ESM also supports dynamic imports:

```tsx
import(`map-fns/mergeInMap`)
  .then(module => {
    // ...
  });
```


## Add `module` field to `package.json`

The module field is described like so:

> An ECMAScript module ID that is the primary entry point to your program.

We now set `pkg.module` to `"index.esm.js"`.


## Fix export default warning for CJS

This was being emitted for every module on `npm run build`:

> (!) Entry module "src/{module}.ts" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "src/{module}.ts" to use named exports only.

Using `module.exports` is intended, so this error was suppressed by setting `outputþexports` to `"auto"`.


## Check `index.esm.js` content in `build:validate-output`

We check that the `index.esm.js` contains the exports that it should like so:

```tsx
console.log("\nEnsuring that the index.esm.js file exports every function.\n");

{
  // The end of index.esm.js should contain a line that exports every function:
  //
  //    export { fnA, fnB, fnC };
  //
  // This regex matches the function list "fnA, fnB, fnC".
  //
  const exportsRegex = /export { (?<exportsStr>([a-z]+(, )?)+) }/i;

  const { exportsStr } = indexEsmContent.match(exportsRegex)!.groups;
  const exportedFunctionsSet = new Set(exportsStr.split(", ").filter(Boolean));

  for (const fileName of fnFileNames) {
    const withoutDotTs = fileName.split(".ts")[0];
    if (!exportedFunctionsSet.has(withoutDotTs)) {
      throw new Error(
        `Expected index.esm.js to export function '${withoutDotTs}'.`
      );
    }

    console.log(`\t✔ ${withoutDotTs}`);
  }
}
```