### PR TITLE
Write README

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[markdown]": {
+    "editor.formatOnSave": false
+  },
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2022 Alex Harri Jónsson <alexharri2919@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# `map-fns`
+<h1 align="center">
+  <code>map-fns</code>
+</h1>
 
+<p align="center">
 Easily manipulate key-value stores in the browser and Node.js.
+</p>
 
 ---
 
@@ -11,6 +15,7 @@ Easily manipulate key-value stores in the browser and Node.js.
 - __Immutable & Pure__: Function arguments are not modified and new objects are returned.
 - __TypeScript__: Well documented and fully typed.
 - __Normal JavaScript objects__: Keeps things simple. No custom classes.
+- __Open Source__: MIT licensed. 
 
 ```tsx
 import { mergeInMap } from "map-fns";
@@ -26,7 +31,7 @@ const map = {
   },
 };
 
-const newMap = mergeInMap(map, "alice", {
+const newMap = mergeInMap(map, ["alice"], {
   permissions: (list) => [...list, "merge"],
 });
 
@@ -43,7 +48,7 @@ console.log(newMap);
 //   }
 ```
 
-`map-fns` supports tree-shaking, but if your environment does not you can import a specific function directly.
+`map-fns` supports tree-shaking. If your environment does not you can import a specific function directly.
 
 ```tsx
 import mergeInMap from "map-fns/mergeInMap";

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 Easily manipulate key-value stores in the browser and Node.js.
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/map-fns" target="_blank">
+    <img src="https://img.shields.io/npm/v/map-fns.svg?style=flat" />
+  </a>
+  <img src="https://img.shields.io/github/checks-status/alexharri/map-fns/master" />
+</p>
+
 ---
 
 ## Why `map-fns`?

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Easily manipulate key-value stores in the browser and Node.js.
   <a href="https://www.npmjs.com/package/map-fns" target="_blank">
     <img src="https://img.shields.io/npm/v/map-fns.svg?style=flat" />
   </a>
-  <img src="https://img.shields.io/github/checks-status/alexharri/map-fns/master" />
+  <a href="https://github.com/alexharri/map-fns/actions/workflows/publish.yml" target="_blank">
+    <img src="https://img.shields.io/github/workflow/status/alexharri/map-fns/Publish%20to%20npm" />
+  </a>
+  <a href="https://app.codecov.io/gh/alexharri/map-fns" target="_blank">
+    <img src="https://img.shields.io/codecov/c/gh/alexharri/map-fns" />
+  </a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Easily manipulate key-value stores in the browser and Node.js.
   <a href="https://app.codecov.io/gh/alexharri/map-fns" target="_blank">
     <img src="https://img.shields.io/codecov/c/gh/alexharri/map-fns" />
   </a>
+  <a href="https://github.com/alexharri/map-fns/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/alexharri/map-fns" />
+  </a>
 </p>
 
 ---
@@ -26,7 +29,7 @@ Easily manipulate key-value stores in the browser and Node.js.
 - __Modular__: Import the functions you need, tree-shake the rest.
 - __Immutable & Pure__: Function arguments are not modified and new objects are returned.
 - __TypeScript__: Well documented and fully typed.
-- __Normal JavaScript objects__: Keeps things simple. No custom classes.
+- __Plain JavaScript objects__: Keep things simple. No custom classes.
 - __Open Source__: MIT licensed. 
 
 ```tsx

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # `map-fns`
 
-This README has yet to be written.
+Easily manipulate key-value stores in the browser and Node.js.
+
+---
+
+## Why `map-fns`?
+
+- __Zero dependencies__: Keep your deployments and node modules lightweight.
+- __Modular__: Import the functions you need, tree-shake the rest.
+- __Immutable & Pure__: Function arguments are not modified and new objects are returned.
+- __TypeScript__: Well documented and fully typed.
+- __Normal JavaScript objects__: Keeps things simple. No custom classes.
+
+```tsx
+import { mergeInMap } from "map-fns";
+
+const map = {
+  alice: {
+    name: "Alice",
+    permissions: ["view"],
+  },
+  bob: {
+    name: "Bob",
+    permissions: ["view", "merge", "push"],
+  },
+};
+
+const newMap = mergeInMap(map, "alice", {
+  permissions: (list) => [...list, "merge"],
+});
+
+console.log(newMap);
+// > {
+//     alice: {
+//       name: "Alice",
+//       permissions: ["view", "merge"],
+//     },
+//     bob: {
+//       name: "Bob",
+//       permissions: ["view", "merge", "push"],
+//     },
+//   }
+```
+
+`map-fns` supports tree-shaking, but if your environment does not you can import a specific function directly.
+
+```tsx
+import mergeInMap from "map-fns/mergeInMap";
+```


### PR DESCRIPTION
# Changes

## Write `README`

It only contains an introduction. It does not contain documentation for every fn. See changes.


## Add `LICENSE`

Adds the MIT license to this project.


## Do not format `markdown` on save

Added `.vscode/settings.json`, which disabled `editor.formatOnSave` for `markdown`.