### PR TITLE
Add `partialMap` function

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ const modules = [
   "mapMap",
   "mapEntries",
   "areMapsShallowEqual",
+  "partialMap",
 ];
 
 for (const module of modules) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { default as addListToMap } from "./addListToMap";
 export { default as mapMap } from "./mapMap";
 export { default as mapEntries } from "./mapEntries";
 export { default as areMapsShallowEqual } from "./areMapsShallowEqual";
+export { default as partialMap } from "./partialMap";

--- a/src/partialMap/index.ts
+++ b/src/partialMap/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./partialMap";

--- a/src/partialMap/partialMap.spec.ts
+++ b/src/partialMap/partialMap.spec.ts
@@ -31,4 +31,11 @@ describe("partialMap", () => {
     expect(map.c === out.c).toEqual(true);
     expect(map.a === out.b).toEqual(false); // Sanity check
   });
+
+  it("throws an error if a key that does not exist in the map is provided", () => {
+    const map: Record<string, number> = { a: 1, b: 2, c: 3 };
+    expect(() => partialMap(map, ["d"])).toThrow(
+      "Key 'd' does not exist in map."
+    );
+  });
 });

--- a/src/partialMap/partialMap.spec.ts
+++ b/src/partialMap/partialMap.spec.ts
@@ -1,0 +1,34 @@
+import partialMap from "./partialMap";
+
+describe("partialMap", () => {
+  it("returns a partial map", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    expect(partialMap(map, ["a", "c"])).toEqual({ a: 1, c: 3 });
+  });
+
+  it("returns an empty object if no keys are provided", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    expect(partialMap(map, [])).toEqual({});
+  });
+
+  it("does not modify the original map", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    expect(partialMap(map, ["a", "b"])).toEqual({ a: 1, b: 2 });
+    expect(map).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("does not modify object references", () => {
+    const a = { value: 1 };
+    const b = { value: 2 };
+    const c = { value: 3 };
+    const map = { a, b, c };
+    const out = partialMap(map, ["b", "c"]);
+    expect(out).toEqual({ b, c });
+    expect(map.a === a).toEqual(true);
+    expect(map.b === b).toEqual(true);
+    expect(map.c === c).toEqual(true);
+    expect(map.b === out.b).toEqual(true);
+    expect(map.c === out.c).toEqual(true);
+    expect(map.a === out.b).toEqual(false); // Sanity check
+  });
+});

--- a/src/partialMap/partialMap.ts
+++ b/src/partialMap/partialMap.ts
@@ -8,7 +8,7 @@ import { AnyMap } from "../types";
  * partialMap({ a: 1, b: 2, c: 3 }, ["a", "c"]);
  * //=> {
  * //     a: 1,
- * //     b: 3,
+ * //     c: 3,
  * //   }
  * ```
  *

--- a/src/partialMap/partialMap.ts
+++ b/src/partialMap/partialMap.ts
@@ -1,0 +1,34 @@
+import { AnyMap } from "../types";
+
+/**
+ * Creates a new map populated with every key in `keys` where the value
+ * behind each `k` in `keys` is `map[k]`.
+ *
+ * ```tsx
+ * partialMap({ a: 1, b: 2, c: 3 }, ["a", "c"]);
+ * //=> {
+ * //     a: 1,
+ * //     b: 3,
+ * //   }
+ * ```
+ *
+ * @param map The original map.
+ * @param keys The keys to include in the new map.
+ * @returns a new `map` populated with every key in `keys` where the value
+ * behind each `k` in `keys` is `map[k]`.
+ */
+export default function partialMap<M extends AnyMap>(
+  map: M,
+  keys: Array<keyof M>
+): M {
+  const obj = {} as M;
+
+  for (const key of keys) {
+    if (!map.hasOwnProperty(key)) {
+      throw new Error(`Key '${key}' does not exist in map.`);
+    }
+    obj[key] = map[key];
+  }
+
+  return obj;
+}

--- a/src/partialMap/partialMap.typecheck.ts
+++ b/src/partialMap/partialMap.typecheck.ts
@@ -1,0 +1,20 @@
+import partialMap from "./partialMap";
+
+partialMap({ a: 1, b: 2, c: 3 }, ["a", "c"]);
+
+/* It returns errors for keys are not in the map */
+
+// @ts-expect-error
+partialMap({ a: 1, b: 2, c: 3 }, ["d"]);
+
+/* Except when properly typed */
+
+partialMap({ a: 1, b: 2, c: 3 } as Record<string, number>, ["d"]);
+
+/* An array of keys must be provided */
+
+// @ts-expect-error
+partialMap({ a: 1, b: 2, c: 3 }, "a");
+
+// @ts-expect-error
+partialMap({ a: 1, b: 2, c: 3 });


### PR DESCRIPTION
# Changes

## Add `partialMap` function

It is useful to get a subset of a map:

```tsx
partialMap({ a: 1, b: 2, c: 3 }, ["a", "c"]);
//=> {
//     a: 1,
//     c: 3,
//   }
```

The implementation is extremely simple, but tedious to write over and over again.

```tsx
/**
 * Creates a new map populated with every key in `keys` where the value
 * behind each `k` in `keys` is `map[k]`.
 *
 * ```tsx
 * partialMap({ a: 1, b: 2, c: 3 }, ["a", "c"]);
 * //=> {
 * //     a: 1,
 * //     c: 3,
 * //   }
 * ```
 *
 * @param map The original map.
 * @param keys The keys to include in the new map.
 * @returns a new `map` populated with every key in `keys` where the value
 * behind each `k` in `keys` is `map[k]`.
 */
export default function partialMap<M extends AnyMap>(
  map: M,
  keys: Array<keyof M>
): M {
  const obj = {} as M;

  for (const key of keys) {
    if (!map.hasOwnProperty(key)) {
      throw new Error(`Key '${key}' does not exist in map.`);
    }
    obj[key] = map[key];
  }

  return obj;
}
```