### PR TITLE
Add examples of using the `partialMap` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,28 @@ mergeInMap(employees, ["alice", "bob"], {
 //     },
 //   }
 ```
+
+
+<h2 id="partialMap">
+  partialMap
+</h2>
+
+[Examples of using `partialMap`](https://github.com/alexharri/map-fns/tree/master/examples/partialMap).
+
+Use `partialMap` to get a copy of a map only including the keys provided in the second argument.
+
+```tsx
+import { partialMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+partialMap(map, ["a", "b"]);
+//=> {
+//     a: 1,
+//     b: 2,
+//   }
+```

--- a/examples/partialMap/01-partial-map.ts
+++ b/examples/partialMap/01-partial-map.ts
@@ -1,0 +1,13 @@
+import { partialMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+partialMap(map, ["a", "b"]);
+//=> {
+//     a: 1,
+//     b: 2,
+//   }


### PR DESCRIPTION
Continues the process of adding examples for each function in the library.