### PR TITLE
Make links to examples in README open in a new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Examples have yet to be created for functions that are not a link.
 
 <p>
   <a href="https://github.com/alexharri/map-fns/tree/master/examples/addListToMap" target="_blank">
-    Examples of using `addListToMap`
+    Examples of using <code>addListToMap</code>
   </a>.
 </p>
 
@@ -127,7 +127,7 @@ addListToMap(
 
 <p>
   <a href="https://github.com/alexharri/map-fns/tree/master/examples/mapEntries" target="_blank">
-    Examples of using `mapEntries`
+    Examples of using <code>mapEntries</code>
   </a>.
 </p>
 
@@ -169,7 +169,7 @@ If a provided key does not exist in the map an error is thrown.
 
 <p>
   <a href="https://github.com/alexharri/map-fns/tree/master/examples/mapMap" target="_blank">
-    Examples of using `mapMap`
+    Examples of using <code>mapMap</code>
   </a>.
 </p>
 
@@ -197,7 +197,7 @@ mapMap(map, (n) => n * 2);
 
 <p>
   <a href="https://github.com/alexharri/map-fns/tree/master/examples/mergeInMap" target="_blank">
-    Examples of using `mergeInMap`
+    Examples of using <code>mergeInMap</code>
   </a>.
 </p>
 
@@ -327,7 +327,7 @@ mergeInMap(employees, ["alice", "bob"], {
 
 <p>
   <a href="https://github.com/alexharri/map-fns/tree/master/examples/partialMap" target="_blank">
-    Examples of using `partialMap`
+    Examples of using <code>partialMap</code>
   </a>.
 </p>
 
@@ -354,7 +354,7 @@ partialMap(map, ["a", "b"]);
 
 <p>
   <a href="https://github.com/alexharri/map-fns/tree/master/examples/removeKeysFromMap" target="_blank">
-    Examples of using `removeKeysFromMap`
+    Examples of using <code>removeKeysFromMap</code>
   </a>.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ Examples have yet to be created for functions that are not a link.
 
 ## addListToMap
 
-<a href="https://github.com/alexharri/map-fns/tree/master/examples/addListToMap" target="_blank">
-  Examples of using `addListToMap`
-</a>.
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/addListToMap" target="_blank">
+    Examples of using `addListToMap`
+  </a>.
+</p>
 
 Use `addListToMap` to add a list of entries to a map.
 
@@ -123,9 +125,11 @@ addListToMap(
 
 ## mapEntries
 
-<a href="https://github.com/alexharri/map-fns/tree/master/examples/mapEntries" target="_blank">
-  Examples of using `mapEntries`
-</a>.
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/mapEntries" target="_blank">
+    Examples of using `mapEntries`
+  </a>.
+</p>
 
 Use `mapEntries` to get the list of key-value entries in a map.
 
@@ -163,9 +167,11 @@ If a provided key does not exist in the map an error is thrown.
 
 ## mapMap
 
-<a href="https://github.com/alexharri/map-fns/tree/master/examples/mapMap" target="_blank">
-  Examples of using `mapMap`
-</a>.
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/mapMap" target="_blank">
+    Examples of using `mapMap`
+  </a>.
+</p>
 
 Use `mapMap` to transform every value in map to a new value with a callback function.
 
@@ -189,9 +195,11 @@ mapMap(map, (n) => n * 2);
 
 ## mergeInMap
 
-<a href="https://github.com/alexharri/map-fns/tree/master/examples/mergeInMap" target="_blank">
-  Examples of using `mergeInMap`
-</a>.
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/mergeInMap" target="_blank">
+    Examples of using `mergeInMap`
+  </a>.
+</p>
 
 Use `mergeInMap` to modify entries in a map deeply.
 
@@ -317,9 +325,11 @@ mergeInMap(employees, ["alice", "bob"], {
 
 ## partialMap
 
-<a href="https://github.com/alexharri/map-fns/tree/master/examples/partialMap" target="_blank">
-  Examples of using `partialMap`
-</a>.
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/partialMap" target="_blank">
+    Examples of using `partialMap`
+  </a>.
+</p>
 
 Use `partialMap` to get a copy of a map only including the keys provided in the second argument.
 
@@ -342,9 +352,11 @@ partialMap(map, ["a", "b"]);
 
 ## removeKeysFromMap
 
-<a href="https://github.com/alexharri/map-fns/tree/master/examples/removeKeysFromMap" target="_blank">
-  Examples of using `removeKeysFromMap`
-</a>.
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/removeKeysFromMap" target="_blank">
+    Examples of using `removeKeysFromMap`
+  </a>.
+</p>
 
 Use `removeKeysFromMap` to get a copy of a map excluding the keys provided in the second argument.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Examples have yet to be created for functions that are not a link.
 
 ## addListToMap
 
-[Examples of using `addListToMap`](https://github.com/alexharri/map-fns/tree/master/examples/addListToMap).
+<a href="https://github.com/alexharri/map-fns/tree/master/examples/addListToMap" target="_blank">
+  Examples of using `addListToMap`
+</a>.
 
 Use `addListToMap` to add a list of entries to a map.
 
@@ -121,7 +123,9 @@ addListToMap(
 
 ## mapEntries
 
-[Examples of using `mapEntries`](https://github.com/alexharri/map-fns/tree/master/examples/mapEntries).
+<a href="https://github.com/alexharri/map-fns/tree/master/examples/mapEntries" target="_blank">
+  Examples of using `mapEntries`
+</a>.
 
 Use `mapEntries` to get the list of key-value entries in a map.
 
@@ -159,7 +163,9 @@ If a provided key does not exist in the map an error is thrown.
 
 ## mapMap
 
-[Examples of using `mapMap`](https://github.com/alexharri/map-fns/tree/master/examples/mapMap).
+<a href="https://github.com/alexharri/map-fns/tree/master/examples/mapMap" target="_blank">
+  Examples of using `mapMap`
+</a>.
 
 Use `mapMap` to transform every value in map to a new value with a callback function.
 
@@ -183,7 +189,9 @@ mapMap(map, (n) => n * 2);
 
 ## mergeInMap
 
-[Examples of using `mergeInMap`](https://github.com/alexharri/map-fns/tree/master/examples/mergeInMap).
+<a href="https://github.com/alexharri/map-fns/tree/master/examples/mergeInMap" target="_blank">
+  Examples of using `mergeInMap`
+</a>.
 
 Use `mergeInMap` to modify entries in a map deeply.
 
@@ -309,7 +317,9 @@ mergeInMap(employees, ["alice", "bob"], {
 
 ## partialMap
 
-[Examples of using `partialMap`](https://github.com/alexharri/map-fns/tree/master/examples/partialMap).
+<a href="https://github.com/alexharri/map-fns/tree/master/examples/partialMap" target="_blank">
+  Examples of using `partialMap`
+</a>.
 
 Use `partialMap` to get a copy of a map only including the keys provided in the second argument.
 
@@ -332,7 +342,9 @@ partialMap(map, ["a", "b"]);
 
 ## removeKeysFromMap
 
-[Examples of using `removeKeysFromMap`](https://github.com/alexharri/map-fns/tree/master/examples/removeKeysFromMap).
+<a href="https://github.com/alexharri/map-fns/tree/master/examples/removeKeysFromMap" target="_blank">
+  Examples of using `removeKeysFromMap`
+</a>.
 
 Use `removeKeysFromMap` to get a copy of a map excluding the keys provided in the second argument.
 


### PR DESCRIPTION
I prefer that the current page is not lost when checking out examples of using a function.