### PR TITLE
Add examples of using the `modifyInMap` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,53 @@ mergeInMap(employees, ["alice", "bob"], {
 ```
 
 
+## modifyInMap
+
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/modifyInMap" target="_blank">
+    Examples of using <code>modifyInMap</code>
+  </a>.
+</p>
+
+Use `modifyInMap` to modify entries in a map.
+
+```tsx
+import { modifyInMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+modifyInMap(map, "a", (n) => n * 10);
+//=> {
+//     a: 10,
+//     b: 2,
+//     c: 3,
+//   }
+```
+
+Multiple entries can be modified by providing an array of keys as the second argument.
+
+```tsx
+import { modifyInMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+modifyInMap(map, ["a", "c"], (n) => n * 10);
+//=> {
+//     a: 10,
+//     b: 2,
+//     c: 30,
+//   }
+```
+
+
 ## partialMap
 
 <p>

--- a/examples/modifyInMap/01-modify-item.ts
+++ b/examples/modifyInMap/01-modify-item.ts
@@ -1,0 +1,14 @@
+import { modifyInMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+modifyInMap(map, "a", (n) => n * 10);
+//=> {
+//     a: 10,
+//     b: 2,
+//     c: 3,
+//   }

--- a/examples/modifyInMap/02-modify-multiple-items.ts
+++ b/examples/modifyInMap/02-modify-multiple-items.ts
@@ -1,0 +1,14 @@
+import { modifyInMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+modifyInMap(map, ["a", "c"], (n) => n * 10);
+//=> {
+//     a: 10,
+//     b: 2,
+//     c: 30,
+//   }

--- a/examples/modifyInMap/03-modify-object.ts
+++ b/examples/modifyInMap/03-modify-object.ts
@@ -1,0 +1,17 @@
+import { modifyInMap } from "map-fns";
+
+const map = {
+  a: { id: "a", value: 1 },
+  b: { id: "b", value: 2 },
+  c: { id: "c", value: 3 },
+};
+
+// Note:  When modifying objects, I would recommend using
+//        the `mergeInMap` function instead.
+
+modifyInMap(map, ["a", "c"], (item) => ({ ...item, value: item.value * 10 }));
+//=> {
+//     a: { id: "a", value: 10 },
+//     b: { id: "b", value: 2 },
+//     c: { id: "c", value: 30 },
+//   }


### PR DESCRIPTION
Continues the process of adding examples for each function in the library.