### PR TITLE
Add `mapPartialMap` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ import mergeInMap from "map-fns/mergeInMap";
  * [areMapsShallowEqual](#areMapsShallowEqual)
  * [mapEntries](#mapEntries)
  * [mapMap](#mapMap)
+ * [mapPartialMap](#mapPartialMap)
  * [mergeInMap](#mergeInMap)
  * [modifyInMap](#modifyInMap)
  * [partialMap](#partialMap)
@@ -256,6 +257,59 @@ mapMap(map, (n) => n * 2);
 //     c: 6,
 //   }
 ```
+
+
+## mapPartialMap
+
+<p>
+  <a href="https://github.com/alexharri/map-fns/tree/master/examples/mapPartialMap" target="_blank">
+    Examples of using <code>mapPartialMap</code>
+  </a>.
+</p>
+
+Use `mapPartialMap` to transform a every value in a partial map.
+
+```tsx
+import { mapPartialMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+mapPartialMap(map, ["a", "c"], (n) => n * 10);
+//=> {
+//     a: 10,
+//     c: 30,
+//   }
+```
+
+Using `mapPartialMap(map, keys, callback)` is equivalent to using `mapMap(partialMap(map, keys), callback)`.
+
+```tsx
+import { mapPartialMap, mapMap, partialMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+mapPartialMap(map, ["a", "c"], (n) => n * 10);
+//=> {
+//     a: 10,
+//     c: 30,
+//   }
+
+mapMap(partialMap(map, ["a", "c"]), (n) => n * 10);
+//=> {
+//     a: 10,
+//     c: 30,
+//   }
+```
+
+`mapPartialMap` exists to improve readability and ease-of-use.
 
 
 ## mergeInMap

--- a/examples/mapPartialMap/01-map-partial-map.ts
+++ b/examples/mapPartialMap/01-map-partial-map.ts
@@ -1,0 +1,13 @@
+import { mapPartialMap } from "map-fns";
+
+const map = {
+  a: 1,
+  b: 2,
+  c: 3,
+};
+
+mapPartialMap(map, ["a", "c"], (n) => n * 10);
+//=> {
+//     a: 10,
+//     c: 30,
+//   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ const modules = [
   "mapEntries",
   "areMapsShallowEqual",
   "partialMap",
+  "mapPartialMap",
 ];
 
 for (const module of modules) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { default as modifyInMap } from "./modifyInMap";
 export { default as mergeInMap } from "./mergeInMap";
 export { default as addListToMap } from "./addListToMap";
 export { default as mapMap } from "./mapMap";
+export { default as mapPartialMap } from "./mapPartialMap";
 export { default as mapEntries } from "./mapEntries";
 export { default as areMapsShallowEqual } from "./areMapsShallowEqual";
 export { default as partialMap } from "./partialMap";

--- a/src/mapPartialMap/index.ts
+++ b/src/mapPartialMap/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./mapPartialMap";

--- a/src/mapPartialMap/mapPartialMap.spec.ts
+++ b/src/mapPartialMap/mapPartialMap.spec.ts
@@ -1,6 +1,16 @@
 import mapPartialMap from "./mapPartialMap";
+import mapMap from "../mapMap";
+import partialMap from "../partialMap";
 
 describe("mapPartialMap", () => {
+  test("mapPartialMap() is equivalent to mapMap(partialMap())", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    const a = mapPartialMap(map, ["a", "c"], (n) => n * 10);
+    const b = mapMap(partialMap(map, ["a", "c"]), (n) => n * 10);
+    expect(a).toEqual({ a: 10, c: 30 });
+    expect(a).toEqual(b);
+  });
+
   it("transforms a map as expected", () => {
     const map = { a: 1, b: 2, c: 3 };
     const keys = Object.keys(map) as Array<keyof typeof map>;

--- a/src/mapPartialMap/mapPartialMap.spec.ts
+++ b/src/mapPartialMap/mapPartialMap.spec.ts
@@ -1,0 +1,55 @@
+import mapPartialMap from "./mapPartialMap";
+
+describe("mapPartialMap", () => {
+  it("transforms a map as expected", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    const keys = Object.keys(map) as Array<keyof typeof map>;
+    const out = mapPartialMap(map, keys, (n) => n * 2);
+    expect(out).toEqual({ a: 2, b: 4, c: 6 });
+  });
+
+  it("does not modify the original map", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    const keys = Object.keys(map) as Array<keyof typeof map>;
+    const out = mapPartialMap(map, keys, (n) => n * 2);
+    expect(map).toEqual({ a: 1, b: 2, c: 3 });
+    expect(out).toEqual({ a: 2, b: 4, c: 6 });
+  });
+
+  it("does not modify object references in the original map", () => {
+    const a = { value: 1 };
+    const b = { value: 2 };
+    const c = { value: 3 };
+    const map = { a, b, c };
+    const keys = Object.keys(map) as Array<keyof typeof map>;
+    const out = mapPartialMap(map, keys, (item) => ({ value: item.value * 2 }));
+    expect(map).toEqual({ a: { value: 1 }, b: { value: 2 }, c: { value: 3 } });
+    expect(out).toEqual({ a: { value: 2 }, b: { value: 4 }, c: { value: 6 } });
+    expect(map.a === a).toBe(true);
+    expect(map.b === b).toBe(true);
+    expect(map.c === c).toBe(true);
+    expect(out.a === a).toBe(false);
+    expect(out.b === b).toBe(false);
+    expect(out.c === c).toBe(false);
+  });
+
+  it("returns a partial map", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    expect(mapPartialMap(map, ["a", "c"], (n) => n * 10)).toEqual({
+      a: 10,
+      c: 30,
+    });
+  });
+
+  it("returns an empty object if no keys are provided", () => {
+    const map = { a: 1, b: 2, c: 3 };
+    expect(mapPartialMap(map, [], (n) => n * 1)).toEqual({});
+  });
+
+  it("throws an error if a key that does not exist in the map is provided", () => {
+    const map: Record<string, number> = { a: 1, b: 2, c: 3 };
+    expect(() => mapPartialMap(map, ["d"], (n) => n * 10)).toThrow(
+      "Key 'd' does not exist in map."
+    );
+  });
+});

--- a/src/mapPartialMap/mapPartialMap.ts
+++ b/src/mapPartialMap/mapPartialMap.ts
@@ -1,0 +1,35 @@
+import { AnyMap, ItemInMap } from "../types";
+
+/**
+ * Creates a new map populated with every key in `keys` where the value
+ * behind each `k` in `keys` is `callback(map[k])`.
+ *
+ * ```tsx
+ * mapPartialMap({ a: 1, b: 2, c: 3 }, ["a", "c"], (n) => n * 2);
+ * //=> {
+ * //     a: 2,
+ * //     c: 6,
+ * //   }
+ * ```
+ *
+ * @param map The original map.
+ * @param keys The keys to include in the new map.
+ * @param callback A function that takes a single argument `map[k]` and returns the value of `newMap[k]`.
+ * @returns A new `map` where `map[k]` is the result of `callback(map[k])`.
+ */
+export default function mapPartialMap<M extends AnyMap, T>(
+  map: M,
+  keys: Array<keyof M>,
+  callback: (item: ItemInMap<M>) => T
+) {
+  const obj = {} as Record<keyof M, T>;
+
+  for (const key of keys) {
+    if (!map.hasOwnProperty(key)) {
+      throw new Error(`Key '${key}' does not exist in map.`);
+    }
+    obj[key] = callback(map[key]);
+  }
+
+  return obj;
+}

--- a/src/mapPartialMap/mapPartialMap.typecheck.ts
+++ b/src/mapPartialMap/mapPartialMap.typecheck.ts
@@ -1,0 +1,29 @@
+import mapPartialMap from "./mapPartialMap";
+
+/** Types are correctly inferred */
+
+mapPartialMap({ a: 1 }, ["a"], (n) => n * 2);
+
+// @ts-expect-error
+mapPartialMap({ a: "1" }, ["a"], (n) => n * 2);
+
+/* It returns errors for keys are not in the map */
+
+// @ts-expect-error
+mapPartialMap({ a: 1, b: 2, c: 3 }, ["d"], (n) => n * 2);
+
+/* Except when properly typed */
+
+mapPartialMap(
+  { a: 1, b: 2, c: 3 } as Record<string, number>,
+  ["d"],
+  (n) => n * 2
+);
+
+/* An array of keys must be provided */
+
+// @ts-expect-error
+mapPartialMap({ a: 1, b: 2, c: 3 }, "a", (n) => n * 2);
+
+// @ts-expect-error
+mapPartialMap({ a: 1, b: 2, c: 3 }, (n) => n * 2);


### PR DESCRIPTION
# Changes

## Add `mapPartialMap` function

Using `mapPartialMap(map, keys, callback)` is equivalent to using `mapMap(partialMap(map, keys), callback)`.

```tsx
import { mapPartialMap, mapMap, partialMap } from "map-fns";

const map = {
  a: 1,
  b: 2,
  c: 3,
};

mapPartialMap(map, ["a", "c"], (n) => n * 10);
//=> {
//     a: 10,
//     c: 30,
//   }

mapMap(partialMap(map, ["a", "c"]), (n) => n * 10);
//=> {
//     a: 10,
//     c: 30,
//   }
```

`mapPartialMap` exists to improve readability and ease-of-use.

The implementation is simple:

```tsx
/**
 * Creates a new map populated with every key in `keys` where the value
 * behind each `k` in `keys` is `callback(map[k])`.
 *
 * ```tsx
 * mapPartialMap({ a: 1, b: 2, c: 3 }, ["a", "c"], (n) => n * 2);
 * //=> {
 * //     a: 2,
 * //     c: 6,
 * //   }
 * ```
 *
 * @param map The original map.
 * @param keys The keys to include in the new map.
 * @param callback A function that takes a single argument `map[k]` and returns the value of `newMap[k]`.
 * @returns A new `map` where `map[k]` is the result of `callback(map[k])`.
 */
export default function mapPartialMap<M extends AnyMap, T>(
  map: M,
  keys: Array<keyof M>,
  callback: (item: ItemInMap<M>) => T
) {
  const obj = {} as Record<keyof M, T>;

  for (const key of keys) {
    if (!map.hasOwnProperty(key)) {
      throw new Error(`Key '${key}' does not exist in map.`);
    }
    obj[key] = callback(map[key]);
  }

  return obj;
}

```